### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Python Client for Dialogflow CX API
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-dialogflow-cx.svg
    :target: https://pypi.org/project/google-cloud-dialogflow-cx/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dialogflow-cx.svg
@@ -79,4 +79,4 @@ Next Steps
    APIs that we cover.
 
 .. _Dialogflow CX API Product documentation: https://cloud.google.com/dialogflow/cx/docs
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.